### PR TITLE
Add breakout menus and callback functions to ACDC queues

### DIFF
--- a/applications/acdc/src/acdc_agent_fsm.erl
+++ b/applications/acdc/src/acdc_agent_fsm.erl
@@ -28,6 +28,7 @@
          ,refresh/2
          ,current_call/1
          ,status/1
+         ,awaiting_callback/1
 
          ,new_endpoint/2
          ,edited_endpoint/2
@@ -50,6 +51,7 @@
          ,sync/2
          ,ready/2
          ,ringing/2
+         ,awaiting_callback/2
          ,answered/2
          ,wrapup/2
          ,paused/2
@@ -59,6 +61,7 @@
          ,sync/3
          ,ready/3
          ,ringing/3
+         ,awaiting_callback/3
          ,answered/3
          ,wrapup/3
          ,paused/3
@@ -108,6 +111,7 @@
                 ,queue_notifications :: api_object()
 
                 ,agent_call_id :: api_binary()
+                ,originate_call_ids = []
                 ,next_status :: api_binary()
                 ,fsm_call_id :: api_binary() % used when no call-ids are available
                 ,endpoints = [] :: wh_json:objects()
@@ -165,7 +169,7 @@ call_event(FSM, <<"call_event">>, <<"LEG_CREATED">>, JObj) ->
 call_event(FSM, <<"call_event">>, <<"LEG_DESTROYED">>, JObj) ->
     gen_fsm:send_event(FSM, {'leg_destroyed', callid(JObj)});
 call_event(FSM, <<"call_event">>, <<"CHANNEL_ANSWER">>, JObj) ->
-    gen_fsm:send_event(FSM, {'channel_answered', callid(JObj)});
+    gen_fsm:send_event(FSM, {'channel_answered', JObj});
 call_event(FSM, <<"call_event">>, <<"DTMF">>, EvtJObj) ->
     gen_fsm:send_event(FSM, {'dtmf_pressed', wh_json:get_value(<<"DTMF-Digit">>, EvtJObj)});
 call_event(FSM, <<"call_event">>, <<"CHANNEL_EXECUTE_COMPLETE">>, JObj) ->
@@ -187,7 +191,7 @@ call_event(_, _C, _E, _) -> 'ok'.
 maybe_send_execute_complete(FSM, <<"bridge">>, JObj) ->
     gen_fsm:send_event(FSM, {'channel_unbridged', callid(JObj)});
 maybe_send_execute_complete(FSM, <<"call_pickup">>, JObj) ->
-    gen_fsm:send_event(FSM, {'channel_bridged', callid(JObj)});
+    gen_fsm:send_event(FSM, {'channel_bridged', JObj});
 maybe_send_execute_complete(_, _, _) -> 'ok'.
 
 %%--------------------------------------------------------------------
@@ -261,6 +265,13 @@ current_call(FSM) -> gen_fsm:sync_send_event(FSM, 'current_call').
 
 -spec status(pid()) -> wh_proplist().
 status(FSM) -> gen_fsm:sync_send_event(FSM, 'status').
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec awaiting_callback(pid()) -> 'ok'.
+awaiting_callback(FSM) -> gen_fsm:send_event(FSM, 'wait_for_callback').
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -549,7 +560,13 @@ ready({'member_connect_win', JObj}, #state{agent_listener=AgentListener
                     acdc_agent_listener:member_connect_retry(AgentListener, JObj),
                     {'next_state', 'ready', State#state{connect_failures=CF+1}};
                 {'ok', UpdatedEPs} ->
-                    acdc_agent_listener:bridge_to_member(AgentListener, Call, JObj, UpdatedEPs, CDRUrl, RecordingUrl),
+                    %% Need to check if a callback is required to the caller
+                    case wh_json:get_value(<<"Callback-Number">>, JObj) of
+                        'undefined' ->
+                            acdc_agent_listener:bridge_to_member(AgentListener, Call, JObj, UpdatedEPs, CDRUrl, RecordingUrl);
+                        Number ->
+                            acdc_agent_listener:redial_member(AgentListener, Call, JObj, UpdatedEPs, CDRUrl, RecordingUrl, Number)
+                    end,
 
                     CIDName = whapps_call:caller_id_name(Call),
                     CIDNum = whapps_call:caller_id_number(Call),
@@ -624,7 +641,7 @@ ready('status', _, State) ->
     {'reply', [{'state', <<"ready">>}], 'ready', State};
 ready('current_call', _, State) ->
     {'reply', 'undefined', 'ready', State}.
-
+    
 %%--------------------------------------------------------------------
 %% @private
 %% @doc
@@ -707,12 +724,12 @@ ringing({'agent_timeout', _JObj}, #state{agent_listener=AgentListener
      ,clear_call(State, 'failed')
     };
 ringing({'channel_bridged', MemberCallId}, #state{member_call_id=MemberCallId
-                                             ,member_call=MemberCall
-                                             ,agent_listener=AgentListener
-                                             ,account_id=AccountId
-                                             ,agent_id=AgentId
-                                             ,queue_notifications=Ns
-                                            }=State) ->
+                                                  ,member_call=MemberCall
+                                                  ,agent_listener=AgentListener
+                                                  ,account_id=AccountId
+                                                  ,agent_id=AgentId
+                                                  ,queue_notifications=Ns
+                                                 }=State) ->
     lager:debug("agent phone has been connected to caller"),
     acdc_agent_listener:member_connect_accepted(AgentListener),
 
@@ -780,29 +797,32 @@ ringing({'dtmf_pressed', DTMF}, #state{caller_exit_key=DTMF
 ringing({'dtmf_pressed', DTMF}, #state{caller_exit_key=_ExitKey}=State) ->
     lager:debug("caller pressed ~s, exit key is ~s", [DTMF, _ExitKey]),
     {'next_state', 'ringing', State};
-ringing({'channel_answered', ACallId}, #state{agent_call_id=ACallId
-                                              ,member_call_id=MemberCallId
-                                              ,member_call=MemberCall
-                                              ,account_id=AccountId
-                                              ,agent_id=AgentId
-                                              ,agent_listener=AgentListener
-                                             }=State) ->
-    lager:debug("agent answered phone on ~s", [ACallId]),
+ringing({'channel_answered', JObj}=Evt, #state{agent_call_id=ACallId
+                                               ,member_call_id=MemberCallId
+                                               ,member_call=MemberCall
+                                               ,account_id=AccountId
+                                               ,agent_id=AgentId
+                                               ,agent_listener=AgentListener
+                                              }=State) ->
+    case callid(JObj) of
+        ACallId ->
+            lager:debug("agent answered phone on ~s", [ACallId]),
 
-    CIDName = whapps_call:caller_id_name(MemberCall),
-    CIDNum = whapps_call:caller_id_number(MemberCall),
+            CIDName = whapps_call:caller_id_name(MemberCall),
+            CIDNum = whapps_call:caller_id_number(MemberCall),
 
-    acdc_agent_stats:agent_connected(AccountId, AgentId, MemberCallId, CIDName, CIDNum),
+            acdc_agent_stats:agent_connected(AccountId, AgentId, MemberCallId, CIDName, CIDNum),
 
-    acdc_agent_listener:presence_update(AgentListener, ?PRESENCE_RED_SOLID),
+            acdc_agent_listener:presence_update(AgentListener, ?PRESENCE_RED_SOLID),
 
-    {'next_state', 'answered', State#state{connect_failures=0}};
-ringing({'channel_answered', MemberCallId}, #state{member_call_id=MemberCallId}=State) ->
-    lager:debug("caller's channel answered"),
-    {'next_state', 'ringing', State};
-ringing({'channel_answered', ACallId}=Evt, #state{agent_call_id=_NotACallId}=State) ->
-    lager:debug("recv answer for ~s, not ~s", [ACallId, _NotACallId]),
-    ringing(Evt, State#state{agent_call_id=ACallId});
+            {'next_state', 'answered', State#state{connect_failures=0}};
+        MemberCallId ->
+            lager:debug("caller's channel answered"),
+            {'next_state', 'ringing', State};
+        _NotACallId ->
+            lager:debug("recv answer for ~s, not ~s", [ACallId, _NotACallId]),
+            ringing(Evt, State#state{agent_call_id=ACallId})
+    end;
 ringing({'sync_req', JObj}, #state{agent_listener=AgentListener}=State) ->
     lager:debug("recv sync_req from ~s", [wh_json:get_value(<<"Process-ID">>, JObj)]),
     acdc_agent_listener:send_sync_resp(AgentListener, 'ringing', JObj),
@@ -832,6 +852,8 @@ ringing({'originate_resp', ACallId}, #state{agent_listener=AgentListener
 ringing(?NEW_CHANNEL_TO(_CallId), State) ->
     lager:debug("new channel ~s for agent", [_CallId]),
     {'next_state', 'ringing', State};
+ringing('wait_for_callback', State) ->
+    {'next_state', 'awaiting_callback', State};
 ringing(_Evt, State) ->
     lager:debug("unhandled event while ringing: ~p", [_Evt]),
     {'next_state', 'ringing', State}.
@@ -848,6 +870,149 @@ ringing('current_call', _, #state{member_call=Call
                                   ,member_call_queue_id=QueueId
                                  }=State) ->
     {'reply', current_call(Call, 'ringing', QueueId, 'undefined'), 'ringing', State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+awaiting_callback({'originate_started', ACallId}, #state{queue_notifications=Ns
+                                                        }=State) ->
+    lager:debug("originate started on ~s, connecting to caller", [ACallId]),
+
+    maybe_notify(Ns, ?NOTIFY_PICKUP, State),
+
+    {'next_state', 'awaiting_callback', State#state{agent_call_id=ACallId
+                                                   ,connect_failures=0
+                                                   }};
+awaiting_callback({'originate_uuid', ACallId, ACtrlQ}, #state{agent_listener=AgentListener
+                                                              ,originate_call_ids=OriginateCallIds}=State) ->
+    lager:debug("recv originate_uuid for agent call ~s(~s)", [ACallId, ACtrlQ]),
+    acdc_agent_listener:originate_uuid(AgentListener, ACallId, ACtrlQ),
+    acdc_util:bind_to_call_events(ACallId, AgentListener),
+    {'next_state', 'awaiting_callback', State#state{originate_call_ids=[ACallId | lists:delete(ACallId, OriginateCallIds)]}};
+awaiting_callback({'originate_resp', ACallId}, #state{agent_listener=AgentListener
+                                                      ,queue_notifications=Ns
+                                                      ,originate_call_ids=OriginateCallIds
+                                                     }=State) ->
+    lager:debug("originate resp on ~s, connecting to caller", [ACallId]),
+
+    maybe_notify(Ns, ?NOTIFY_PICKUP, State),
+
+    %% Unbind from the other legs of the agent's call
+    lists:foreach(fun(OtherCallId) ->
+        acdc_util:unbind_from_call_events(OtherCallId, AgentListener)
+    end, lists:delete(ACallId, OriginateCallIds)),
+
+    {'next_state', 'awaiting_callback', State#state{agent_call_id=ACallId
+                                                    ,connect_failures=0
+                                                    ,originate_call_ids=[]
+                                                   }};
+awaiting_callback({'call_from', MemberCallId}, #state{agent_listener=AgentListener
+                                                     }=State) ->
+    lager:debug("Event call_from for callback (call id ~p)", [MemberCallId]),
+    acdc_util:bind_to_call_events(MemberCallId, AgentListener),
+
+    %% Update others on new call
+    acdc_agent_listener:replace_call(AgentListener, whapps_call:set_call_id(MemberCallId, whapps_call:new())),
+
+    {'next_state', 'awaiting_callback', State#state{member_call_id=MemberCallId
+                                                   }};
+awaiting_callback({'channel_answered', JObj}=Evt, #state{agent_call_id=ACallId
+                                                     ,member_call_id=MemberCallId
+                                                     ,agent_listener=AgentListener
+                                                     ,originate_call_ids=OriginateCallIds
+                                                    }=State) ->
+    CallId = callid(JObj),
+
+    case {CallId, lists:member(CallId, OriginateCallIds)} of
+        {ACallId, _} ->
+            NewAgentCall = whapps_call:from_json(JObj),
+            lager:debug("agent answered phone on ~s, now calling back to the member", [CallId]),
+            acdc_agent_listener:callback_announce(AgentListener, NewAgentCall),
+            acdc_agent_listener:presence_update(AgentListener, ?PRESENCE_RED_SOLID),
+            {'next_state', 'awaiting_callback', State#state{connect_failures=0}};
+        {_, 'true'} ->
+            NewAgentCall = whapps_call:from_json(JObj),
+            lager:debug("agent answered phone on ~s, now calling back to the member", [CallId]),
+            acdc_agent_listener:callback_announce(AgentListener, NewAgentCall),
+            acdc_agent_listener:presence_update(AgentListener, ?PRESENCE_RED_SOLID),
+            {'next_state', 'awaiting_callback', State#state{connect_failures=0}};
+        {MemberCallId, _} ->
+            NewMemberCall = whapps_call:from_json(JObj),
+            lager:debug("Member answered their callback"),
+            acdc_agent_listener:replace_call(AgentListener, NewMemberCall),
+            {'next_state', 'awaiting_callback', State#state{member_call=NewMemberCall
+                                                           }};
+        _ ->
+            lager:debug("unhandled event while awaiting callback: ~p", [Evt]),
+            {'next_state', 'awaiting_callback', State}
+    end;
+awaiting_callback({'channel_bridged', _CallId}, #state{agent_listener=AgentListener
+                                                    ,agent_call_id=ACallId
+                                                    ,member_call=MemberCall
+                                                    ,member_call_id=MemberCallId
+                                                    ,account_id=AccountId
+                                                    ,agent_id=AgentId
+                                                    ,queue_notifications=Ns
+                                                   }=State) ->
+    acdc_agent_listener:member_connect_accepted(AgentListener, ACallId, MemberCall),
+
+    maybe_notify(Ns, ?NOTIFY_PICKUP, State),
+
+    CIDName = whapps_call:caller_id_name(MemberCall),
+    CIDNum = whapps_call:caller_id_number(MemberCall),
+
+    acdc_agent_stats:agent_connected(AccountId, AgentId, MemberCallId, CIDName, CIDNum),
+
+    {'next_state', 'answered', State#state{connect_failures=0}};
+awaiting_callback({'channel_hungup', MemberCallId, Reason}, #state{account_id=AccountId
+                                                                   ,member_call_queue_id=QueueId
+                                                                   ,member_call_id=MemberCallId
+                                                                   ,agent_listener=AgentListener
+                                                                   ,agent_id=AgentId
+                                                                  }=State) ->
+    lager:debug("caller did not pick up callback on ~p (~p)", [MemberCallId, Reason]),
+    acdc_agent_listener:channel_hungup(AgentListener, MemberCallId),
+
+    acdc_stats:call_processed(AccountId, QueueId, AgentId, MemberCallId),
+    acdc_agent_stats:agent_ready(AccountId, AgentId),
+
+    acdc_agent_listener:presence_update(AgentListener, ?PRESENCE_GREEN),
+    {'next_state', 'ready', clear_call(State, 'ready')};
+awaiting_callback({'agent_timeout', _JObj}, #state{agent_listener=AgentListener
+                                                   ,account_id=AccountId
+                                                   ,agent_id=AgentId
+                                                   ,member_call_queue_id=QueueId
+                                                   ,member_call_id=CallId
+                                                   ,connect_failures=Fails
+                                                   ,max_connect_failures=MaxFails
+                                                  }=State) ->
+    acdc_agent_listener:agent_timeout(AgentListener),
+    lager:debug("recv timeout from queue process"),
+    acdc_stats:call_missed(AccountId, QueueId, AgentId, CallId, <<"timeout">>),
+
+    acdc_agent_listener:presence_update(AgentListener, ?PRESENCE_GREEN),
+    {'next_state'
+     ,return_to_state(Fails+1, MaxFails, AccountId, AgentId)
+     ,clear_call(State, 'failed')
+    };
+awaiting_callback(_Evt, State) ->
+    lager:debug("unhandled event while awaiting callback: ~p", [_Evt]),
+    {'next_state', 'awaiting_callback', State}.
+
+awaiting_callback('status', _, #state{member_call_id=MemberCallId
+                                      ,agent_call_id=ACallId
+                                     }=State) ->
+    {'reply', [{'state', <<"awaiting_callback">>}
+               ,{'member_call_id', MemberCallId}
+               ,{'agent_call_id', ACallId}
+              ]
+     ,'ringing', State};
+awaiting_callback('current_call', _, #state{member_call=Call
+                                            ,member_call_queue_id=QueueId
+                                           }=State) ->
+    {'reply', current_call(Call, 'awaiting_callback', QueueId, 'undefined'), 'awaiting_callback', State}.
 
 %%--------------------------------------------------------------------
 %% @private
@@ -915,12 +1080,20 @@ answered({'channel_unbridged', CallId}, #state{member_call_id=CallId}=State) ->
 answered({'channel_unbridged', CallId}, #state{agent_call_id=CallId}=State) ->
     lager:debug("agent channel unbridged"),
     {'next_state', 'wrapup', State#state{wrapup_ref=hangup_call(State)}};
-answered({'channel_answered', MemberCallId}, #state{member_call_id=MemberCallId}=State) ->
-    lager:debug("member's channel has answered"),
-    {'next_state', 'answered', State};
-answered({'channel_answered', ACallId}, #state{agent_call_id=ACallId}=State) ->
-    lager:debug("agent's channel ~s has answered", [ACallId]),
-    {'next_state', 'answered', State};
+answered({'channel_answered', JObj}=Evt, #state{agent_call_id=AgentCallId
+                                              ,member_call_id=MemberCallId
+                                             }=State) ->
+    case callid(JObj) of
+        AgentCallId ->
+            lager:debug("agent's channel ~s has answered", [AgentCallId]),
+            {'next_state', 'answered', State};
+        MemberCallId ->
+            lager:debug("member's channel has answered"),
+            {'next_state', 'answered', State};
+        _ ->
+            lager:debug("unhandled event while answered: ~p", [Evt]),
+            {'next_state', 'answered', State}
+    end;
 answered({'originate_started', _CallId}, State) ->
     {'next_state', 'answered', State};
 answered(_Evt, State) ->

--- a/applications/acdc/src/acdc_agent_handler.erl
+++ b/applications/acdc/src/acdc_agent_handler.erl
@@ -245,9 +245,9 @@ handle_new_channel(JObj, AccountId) ->
 -spec handle_new_channel_acct(wh_json:object(), api_binary()) -> 'ok'.
 handle_new_channel_acct(_, 'undefined') -> 'ok';
 handle_new_channel_acct(JObj, AccountId) ->
-    [FromUser, _FromHost] = binary:split(wh_json:get_value(<<"From">>, JObj), <<"@">>),
-    [ToUser, _ToHost] = binary:split(wh_json:get_value(<<"To">>, JObj), <<"@">>),
-    [ReqUser, _ReqHost] = binary:split(wh_json:get_value(<<"Request">>, JObj), <<"@">>),
+	FromUser = hd(binary:split(wh_json:get_value(<<"From">>, JObj), <<"@">>)),
+	ToUser = hd(binary:split(wh_json:get_value(<<"To">>, JObj), <<"@">>)),
+    ReqUser = hd(binary:split(wh_json:get_value(<<"Request">>, JObj), <<"@">>)),
 
     CallId = wh_json:get_value(<<"Call-ID">>, JObj),
 

--- a/applications/acdc/src/acdc_queue_fsm.erl
+++ b/applications/acdc/src/acdc_queue_fsm.erl
@@ -671,8 +671,8 @@ handle_event({'refresh', QueueJObj}, StateName, State) ->
 handle_event({'replace_call', Call}, StateName, #state{connection_timer_ref=ConnRef
                                                        ,agent_ring_timer_ref=AgentRef
                                                       }=State) ->
-    gen_fsm:cancel_timer(ConnRef),
-    gen_fsm:cancel_timer(AgentRef),
+    maybe_stop_timer(ConnRef),
+    maybe_stop_timer(AgentRef),
     lager:debug("Cancelled timeout timers - agent has answered, ignoring lack of bridge to callback for now"),
     lager:debug("Replacing call in queue FSM"),
     {'next_state', StateName, State#state{member_call=Call

--- a/applications/acdc/src/acdc_queue_fsm.erl
+++ b/applications/acdc/src/acdc_queue_fsm.erl
@@ -26,6 +26,8 @@
 
          %% Accessors
          ,cdr_url/1
+
+         ,replace_call/2
         ]).
 
 %% State handlers
@@ -180,6 +182,9 @@ status(FSM) ->
 -spec cdr_url(pid()) -> api_binary().
 cdr_url(FSM) ->
     gen_fsm:sync_send_all_state_event(FSM, 'cdr_url').
+
+replace_call(FSM, Call) ->
+    gen_fsm:send_all_state_event(FSM, {'replace_call', Call}).
 
 %%%===================================================================
 %%% gen_fsm callbacks
@@ -403,11 +408,18 @@ connect_req({'dtmf_pressed', DTMF}, #state{caller_exit_key=DTMF
                                           }=State) when is_binary(DTMF) ->
     lager:debug("member pressed the exit key (~s)", [DTMF]),
 
-    %webseq:evt(self(), whapps_call:call_id(Call), <<"member call finish - DTMF">>),
+    %% Do not exit if exit is suppressed
+    case wh_json:get_value(<<"No-Queue-Exit">>, whapps_call:ccvs(Call)) of
+        'undefined' ->
+            %webseq:evt(self(), whapps_call:call_id(Call), <<"member call finish - DTMF">>),
 
-    acdc_queue_listener:exit_member_call(Srv),
-    acdc_stats:call_abandoned(AccountId, QueueId, whapps_call:call_id(Call), ?ABANDON_EXIT),
-    {'next_state', 'ready', clear_member_call(State), 'hibernate'};
+            acdc_queue_listener:exit_member_call(Srv),
+            acdc_stats:call_abandoned(AccountId, QueueId, whapps_call:call_id(Call), ?ABANDON_EXIT),
+            {'next_state', 'ready', clear_member_call(State), 'hibernate'};
+        <<"true">> ->
+            lager:debug("Exit key ignored for this call"),
+            {'next_state', 'connect_req', State, 'hibernate'}
+    end;
 
 connect_req({'timeout', ConnRef, ?CONNECTION_TIMEOUT_MESSAGE}, #state{queue_proc=Srv
                                                                       ,connection_timer_ref=ConnRef
@@ -475,8 +487,16 @@ connecting({'accepted', AcceptJObj}, #state{queue_proc=Srv
 
             %webseq:evt(self(), whapps_call:call_id(Call), <<"member call - agent acceptance">>),
 
+            HandledCallId = case wh_json:get_value(<<"Old-Call-ID">>, AcceptJObj) of
+                undefined ->
+                    whapps_call:call_id(Call);
+                %% If the old call id is set, it has been replaced with Call-ID
+                _ ->
+                    wh_json:get_value(<<"Call-ID">>, AcceptJObj)
+            end,
+
             acdc_queue_listener:finish_member_call(Srv, AcceptJObj),
-            acdc_stats:call_handled(AccountId, QueueId, whapps_call:call_id(Call)
+            acdc_stats:call_handled(AccountId, QueueId, HandledCallId
                                     ,wh_json:get_value(<<"Agent-ID">>, AcceptJObj)
                                    ),
             {'next_state', 'ready', clear_member_call(State), 'hibernate'};
@@ -532,6 +552,17 @@ connecting({'timeout', _OtherAgentRef, ?AGENT_RING_TIMEOUT_MESSAGE}, #state{agen
     lager:debug("unknown agent ref: ~p known: ~p", [_OtherAgentRef, _AgentRef]),
     {'next_state', 'connect_req', State};
 
+connecting({'member_hungup', _CallEvt}, #state{queue_proc=Srv
+                                              ,connection_timer_ref='undefined'
+                                              ,agent_ring_timer_ref='undefined'
+                                             }=State) ->
+    lager:debug("caller did not answer a callback"),
+    acdc_queue_listener:finish_member_call(Srv),
+
+    %webseq:evt(self(), whapps_call:call_id(Call), <<"member call - hungup">>),
+
+    {'next_state', 'ready', clear_member_call(State), 'hibernate'};
+
 connecting({'member_hungup', CallEvt}, #state{queue_proc=Srv
                                               ,account_id=AccountId
                                               ,queue_id=QueueId
@@ -561,12 +592,19 @@ connecting({'dtmf_pressed', DTMF}, #state{caller_exit_key=DTMF
                                           ,member_call=Call
                                          }=State) when is_binary(DTMF) ->
     lager:debug("member pressed the exit key (~s)", [DTMF]),
-    acdc_queue_listener:exit_member_call(Srv),
 
-    %webseq:evt(self(), whapps_call:call_id(Call), <<"member call finish - DTMF">>),
+    %% Do not exit if exit is suppressed
+    case wh_json:get_value(<<"No-Queue-Exit">>, whapps_call:ccvs(Call)) of
+        'undefined' ->
+            %webseq:evt(self(), whapps_call:call_id(Call), <<"member call finish - DTMF">>),
 
-    acdc_stats:call_abandoned(AccountId, QueueId, whapps_call:call_id(Call), ?ABANDON_EXIT),
-    {'next_state', 'ready', clear_member_call(State), 'hibernate'};
+            acdc_queue_listener:exit_member_call(Srv),
+            acdc_stats:call_abandoned(AccountId, QueueId, whapps_call:call_id(Call), ?ABANDON_EXIT),
+            {'next_state', 'ready', clear_member_call(State), 'hibernate'};
+        <<"true">> ->
+            lager:debug("Exit key ignored for this call"),
+            {'next_state', 'connecting', State, 'hibernate'}
+    end;
 connecting({'dtmf_pressed', _DTMF}, State) ->
     lager:debug("caller pressed ~s, ignoring", [_DTMF]),
     {'next_state', 'connecting', State};
@@ -630,6 +668,17 @@ connecting('current_call', _, #state{member_call=Call
 handle_event({'refresh', QueueJObj}, StateName, State) ->
     lager:debug("refreshing queue configs"),
     {'next_state', StateName, update_properties(QueueJObj, State), 'hibernate'};
+handle_event({'replace_call', Call}, StateName, #state{connection_timer_ref=ConnRef
+                                                       ,agent_ring_timer_ref=AgentRef
+                                                      }=State) ->
+    gen_fsm:cancel_timer(ConnRef),
+    gen_fsm:cancel_timer(AgentRef),
+    lager:debug("Cancelled timeout timers - agent has answered, ignoring lack of bridge to callback for now"),
+    lager:debug("Replacing call in queue FSM"),
+    {'next_state', StateName, State#state{member_call=Call
+                                          ,connection_timer_ref='undefined'
+                                          ,agent_ring_timer_ref='undefined'
+                                         }};
 handle_event(_Event, StateName, State) ->
     lager:debug("unhandled event in state ~s: ~p", [StateName, _Event]),
     {'next_state', StateName, State}.
@@ -791,7 +840,8 @@ elapsed(Time) -> wh_util:elapsed_s(Time).
 
 -spec accept_is_for_call(wh_json:object(), whapps_call:call()) -> boolean().
 accept_is_for_call(AcceptJObj, Call) ->
-    wh_json:get_value(<<"Call-ID">>, AcceptJObj) =:= whapps_call:call_id(Call).
+    (wh_json:get_value(<<"Call-ID">>, AcceptJObj) =:= whapps_call:call_id(Call)) or
+        (wh_json:get_value(<<"Old-Call-ID">>, AcceptJObj) =:= whapps_call:call_id(Call)).
 
 -spec update_agent(wh_json:object(), wh_json:object()) -> wh_json:object().
 update_agent(Agent, Winner) ->

--- a/applications/acdc/src/acdc_queue_handler.erl
+++ b/applications/acdc/src/acdc_queue_handler.erl
@@ -75,7 +75,8 @@ handle_member_callback_reg(JObj, Props) ->
     Srv = props:get_value('server', Props),
     CallId = wh_json:get_value(<<"Call-ID">>, JObj),
     acdc_util:unbind_from_call_events(CallId, Srv),
-    acdc_queue_listener:enter_callback_mode(Srv, wh_json:get_value(<<"Number">>, JObj)).
+
+    acdc_queue_listener:maybe_enter_callback_mode(Srv, CallId, wh_json:get_value(<<"Number">>, JObj)).
 
 handle_member_callback_update(JObj, Props) ->
     lager:debug("Member callback update received by queue"),

--- a/applications/acdc/src/acdc_queue_handler.erl
+++ b/applications/acdc/src/acdc_queue_handler.erl
@@ -13,6 +13,8 @@
          ,handle_member_resp/2
          ,handle_member_accepted/2
          ,handle_member_retry/2
+         ,handle_member_callback_reg/2
+         ,handle_member_callback_update/2
          ,handle_config_change/2
          ,handle_presence_probe/2
         ]).
@@ -67,6 +69,18 @@ handle_member_accepted(JObj, Props) ->
 handle_member_retry(JObj, Props) ->
     'true' = wapi_acdc_queue:member_connect_retry_v(JObj),
     acdc_queue_fsm:member_connect_retry(props:get_value('fsm_pid', Props), JObj).
+
+handle_member_callback_reg(JObj, Props) ->
+    lager:debug("Member callback reg received by queue"),
+    Srv = props:get_value('server', Props),
+    CallId = wh_json:get_value(<<"Call-ID">>, JObj),
+    acdc_util:unbind_from_call_events(CallId, Srv),
+    acdc_queue_listener:enter_callback_mode(Srv, wh_json:get_value(<<"Number">>, JObj)).
+
+handle_member_callback_update(JObj, Props) ->
+    lager:debug("Member callback update received by queue"),
+    Srv = props:get_value('server', Props),
+    acdc_queue_listener:callback_update(Srv, wh_json:get_value(<<"Call">>, JObj)).
 
 -spec handle_config_change(wh_json:object(), wh_proplist()) -> any().
 handle_config_change(JObj, _Props) ->

--- a/applications/acdc/src/acdc_queue_listener.erl
+++ b/applications/acdc/src/acdc_queue_listener.erl
@@ -35,6 +35,9 @@
          ,send_sync_resp/4
 
          ,delivery/1
+
+         ,enter_callback_mode/2
+         ,callback_update/2
         ]).
 
 %% gen_server callbacks
@@ -68,6 +71,8 @@
           ,call :: whapps_call:call()
           ,agent_id :: ne_binary()
           ,delivery :: #'basic.deliver'{}
+
+          ,awaiting_callback
          }).
 -type state() :: #state{}.
 
@@ -90,6 +95,12 @@
                      ,{{'acdc_queue_handler', 'handle_sync_req'}
                        ,[{<<"queue">>, <<"sync_req">>}]
                       }
+                     ,{{'acdc_queue_handler', 'handle_member_callback_reg'}
+                       ,[{<<"member">>, <<"callback_reg">>}]
+                      }
+                     ,{{'acdc_queue_handler', 'handle_member_callback_update'}
+                       ,[{<<"member">>, <<"callback_update">>}]
+                      }
                     ]).
 
 %%%===================================================================
@@ -106,7 +117,7 @@
 -spec start_link(pid(), pid(), ne_binary(), ne_binary()) -> startlink_ret().
 start_link(WorkerSup, MgrPid, AcctId, QueueId) ->
     gen_listener:start_link(?MODULE
-                            ,[{'bindings', [{'acdc_queue', [{'restrict_to', ['sync_req']}
+                            ,[{'bindings', [{'acdc_queue', [{'restrict_to', ['sync_req', 'member_callback_reg']}
                                                             ,{'account_id', AcctId}
                                                             ,{'queue_id', QueueId}
                                                            ]}
@@ -179,6 +190,12 @@ send_sync_resp(Srv, Strategy, StrategyState, ReqJObj) ->
 
 delivery(Srv) ->
     gen_listener:call(Srv, 'delivery').
+
+enter_callback_mode(Srv, Number) ->
+    gen_listener:cast(Srv, {'enter_callback_mode', Number}).
+
+callback_update(Srv, CallJObj) ->
+    gen_listener:cast(Srv, {'callback_update', CallJObj}).
 
 %%%===================================================================
 %%% gen_listener callbacks
@@ -328,10 +345,21 @@ handle_cast({'member_connect_win', RespJObj, QueueOpts}, #state{my_q=MyQ
                                                                 ,my_id=MyId
                                                                 ,call=Call
                                                                 ,queue_id=QueueId
-                                                               }=State) ->
+                                                                ,awaiting_callback=Awaiting
+                                                               }=State) when Awaiting =:= 'undefined' ->
     lager:debug("agent process won the call, sending the win"),
 
     send_member_connect_win(RespJObj, Call, QueueId, MyQ, MyId, QueueOpts),
+    {'noreply', State#state{agent_id=wh_json:get_value(<<"Agent-ID">>, RespJObj)}, 'hibernate'};
+handle_cast({'member_connect_win', RespJObj, QueueOpts}, #state{my_q=MyQ
+                                                                ,my_id=MyId
+                                                                ,call=Call
+                                                                ,queue_id=QueueId
+                                                                ,awaiting_callback=Awaiting
+                                                               }=State) ->
+    lager:debug("agent process won the call, sending the win"),
+
+    send_member_connect_win(RespJObj, Call, QueueId, MyQ, MyId, QueueOpts, Awaiting),
     {'noreply', State#state{agent_id=wh_json:get_value(<<"Agent-ID">>, RespJObj)}, 'hibernate'};
 handle_cast({'timeout_agent', RespJObj}, #state{queue_id=QueueId
                                                 ,call=Call
@@ -454,6 +482,23 @@ handle_cast({'send_sync_resp', Strategy, StrategyState, ReqJObj}, #state{my_id=I
     {'noreply', State};
 handle_cast({'gen_listener',{'is_consuming',_IsConsuming}}, State) ->
     {'noreply', State};
+handle_cast({'enter_callback_mode', Number}, #state{awaiting_callback=_AC}=State) ->
+    {'noreply', State#state{awaiting_callback=Number}};
+handle_cast({'callback_update', CallJObj}, #state{call=Call
+                                                  ,my_id=MyId
+                                                  ,my_q=MyQ
+                                                  ,member_call_queue=MemberCallQ
+                                                  ,fsm_pid=FSM
+                                                  ,mgr_pid=MgrPid
+                                                 }=State) ->
+    acdc_util:unbind_from_call_events(Call),
+    NewCall = whapps_call:from_json(CallJObj),
+    acdc_util:bind_to_call_events(NewCall),
+
+    acdc_queue_fsm:replace_call(FSM, NewCall),
+    acdc_queue_manager:replace_call(MgrPid, Call, NewCall),
+
+    {'noreply', State#state{call=NewCall}};
 handle_cast(_Msg, State) ->
     lager:debug("unhandled cast: ~p", [_Msg]),
     {'noreply', State}.
@@ -524,8 +569,12 @@ send_member_connect_req(CallId, AcctId, QueueId, MyQ, MyId) ->
             ]),
     publish(Req, fun wapi_acdc_queue:publish_member_connect_req/1).
 
--spec send_member_connect_win(wh_json:object(), whapps_call:call(), ne_binary(), ne_binary(), ne_binary(), wh_proplist()) -> 'ok'.
 send_member_connect_win(RespJObj, Call, QueueId, MyQ, MyId, QueueOpts) ->
+    send_member_connect_win(RespJObj, Call, QueueId, MyQ, MyId, QueueOpts, 'false').
+
+-spec send_member_connect_win(wh_json:object(), whapps_call:call(), ne_binary(), ne_binary(), ne_binary(), wh_proplist()
+                              ,boolean()) -> 'ok'.
+send_member_connect_win(RespJObj, Call, QueueId, MyQ, MyId, QueueOpts, 'false') ->
     CallJSON = whapps_call:to_json(Call),
     Q = wh_json:get_value(<<"Server-ID">>, RespJObj),
     Win = props:filter_undefined(
@@ -533,6 +582,18 @@ send_member_connect_win(RespJObj, Call, QueueId, MyQ, MyId, QueueOpts) ->
              ,{<<"Process-ID">>, MyId}
              ,{<<"Agent-Process-ID">>, wh_json:get_value(<<"Agent-Process-ID">>, RespJObj)}
              ,{<<"Queue-ID">>, QueueId}
+             | QueueOpts ++ wh_api:default_headers(MyQ, ?APP_NAME, ?APP_VERSION)
+            ]),
+    publish(Q, Win, fun wapi_acdc_queue:publish_member_connect_win/2);
+send_member_connect_win(RespJObj, Call, QueueId, MyQ, MyId, QueueOpts, CallbackNumber) ->
+    CallJSON = whapps_call:to_json(Call),
+    Q = wh_json:get_value(<<"Server-ID">>, RespJObj),
+    Win = props:filter_undefined(
+            [{<<"Call">>, CallJSON}
+             ,{<<"Process-ID">>, MyId}
+             ,{<<"Agent-Process-ID">>, wh_json:get_value(<<"Agent-Process-ID">>, RespJObj)}
+             ,{<<"Queue-ID">>, QueueId}
+             ,{<<"Callback-Number">>, CallbackNumber}
              | QueueOpts ++ wh_api:default_headers(MyQ, ?APP_NAME, ?APP_VERSION)
             ]),
     publish(Q, Win, fun wapi_acdc_queue:publish_member_connect_win/2).
@@ -635,6 +696,7 @@ clear_call_state(#state{acct_id=AcctId
                 ,member_call_queue='undefined'
                 ,agent_id='undefined'
                 ,delivery='undefined'
+                ,awaiting_callback='undefined'
                }.
 
 -spec publish(api_terms(), wh_amqp_worker:publish_fun()) -> 'ok'.

--- a/applications/acdc/src/acdc_stats.erl
+++ b/applications/acdc/src/acdc_stats.erl
@@ -17,6 +17,8 @@
          ,call_missed/5
          ,call_processed/4
 
+         ,call_id_change/4
+
          ,find_call/1
          ,call_stat_to_json/1
         ]).
@@ -107,6 +109,16 @@ call_processed(AccountId, QueueId, AgentId, CallId) ->
              ]),
     whapps_util:amqp_pool_send(Prop, fun wapi_acdc_stats:publish_call_processed/1).
 
+call_id_change(AccountId, QueueId, OldCallId, NewCallId) ->
+    Prop = props:filter_undefined(
+        [{<<"Account-ID">>, AccountId}
+         ,{<<"Queue-ID">>, QueueId}
+         ,{<<"Old-Call-ID">>, OldCallId}
+         ,{<<"Call-ID">>, NewCallId}
+         | wh_api:default_headers(?APP_NAME, ?APP_VERSION)
+        ]),
+    whapps_util:amqp_pool_send(Prop, fun wapi_acdc_stats:publish_call_id_change/1).
+
 %% ETS config
 call_table_id() -> 'acdc_stats_call'.
 call_key_pos() -> #call_stat.id.
@@ -124,6 +136,9 @@ call_table_opts() ->
                         ,{<<"acdc_call_stat">>, <<"abandoned">>}
                         ,{<<"acdc_call_stat">>, <<"handled">>}
                         ,{<<"acdc_call_stat">>, <<"processed">>}
+                        ,{<<"acdc_call_stat">>, <<"entered-position">>}
+                        ,{<<"acdc_call_stat">>, <<"exited-position">>}
+                        ,{<<"acdc_call_stat">>, <<"id-change">>}
                         ,{<<"acdc_call_stat">>, <<"flush">>}
                        ]
                      }
@@ -163,6 +178,9 @@ handle_call_stat(JObj, Props) ->
         <<"abandoned">> -> handle_abandoned_stat(JObj, Props);
         <<"handled">> -> handle_handled_stat(JObj, Props);
         <<"processed">> -> handle_processed_stat(JObj, Props);
+        <<"entered-position">> -> handle_entered_stat(JObj, Props);
+        <<"exited-position">> -> handle_exited_stat(JObj, Props);
+        <<"id-change">> -> handle_id_change(JObj, Props);
         <<"flush">> -> flush_call_stat(JObj, Props);
         _Name ->
             lager:debug("recv unknown call stat type ~s: ~p", [_Name, JObj])
@@ -235,6 +253,23 @@ handle_cast({'create_status', #status_stat{id=_Id, status=_Status}=Stat}, State)
 handle_cast({'update_call', Id, Updates}, State) ->
     lager:debug("updating call stat ~s: ~p", [Id, Updates]),
     ets:update_element(call_table_id(), Id, Updates),
+    {'noreply', State};
+handle_cast({'replace_call_id', QueueId, OldCallId, NewCallId}, State) ->
+    CallTableId = call_table_id(),
+    OldId = call_stat_id(OldCallId, QueueId),
+    NewId = call_stat_id(NewCallId, QueueId),
+
+    lager:debug("Replacing old stat id ~p with ~p", [OldId, NewId]),
+    [Stat] = ets:select(CallTableId, [{#call_stat{id=OldId
+                                                  ,_='_'
+                                                 }
+                                       ,[]
+                                       ,['$_']
+                                      }]),
+    ets:delete(CallTableId, OldId),
+    ets:insert(CallTableId, Stat#call_stat{id=NewId
+                                           ,call_id=NewCallId
+                                          }),
     {'noreply', State};
 handle_cast({'flush_call', Id}, State) ->
     lager:debug("flushing call stat ~s", [Id]),
@@ -402,6 +437,8 @@ query_calls(RespQ, MsgId, Match, _Limit) ->
                                    ,{<<"handled">>, []}
                                    ,{<<"abandoned">>, []}
                                    ,{<<"processed">>, []}
+                                   ,{<<"entered_position">>, []}
+                                   ,{<<"exited_position">>, []}
                                   ]),
 
             QueryResult = lists:foldl(fun query_call_fold/2, Dict, Stats),
@@ -409,6 +446,8 @@ query_calls(RespQ, MsgId, Match, _Limit) ->
                     ,{<<"Handled">>, dict:fetch(<<"handled">>, QueryResult)}
                     ,{<<"Abandoned">>, dict:fetch(<<"abandoned">>, QueryResult)}
                     ,{<<"Processed">>, dict:fetch(<<"processed">>, QueryResult)}
+                    ,{<<"Entered-Position">>, dict:fetch(<<"entered_position">>, QueryResult)}
+                    ,{<<"Exited-Position">>, dict:fetch(<<"exited_position">>, QueryResult)}
                     ,{<<"Query-Time">>, wh_util:current_tstamp()}
                     ,{<<"Msg-ID">>, MsgId}
                     | wh_api:default_headers(?APP_NAME, ?APP_VERSION)
@@ -534,6 +573,8 @@ call_stat_to_doc(#call_stat{id=Id
                             ,abandoned_timestamp=AbandonedT
                             ,handled_timestamp=HandledT
                             ,processed_timestamp=ProcessedT
+                            ,entered_position=EnteredPos
+                            ,exited_position=ExitedPos
                             ,abandoned_reason=AbandonedR
                             ,misses=Misses
                             ,status=Status
@@ -551,6 +592,8 @@ call_stat_to_doc(#call_stat{id=Id
            ,{<<"abandoned_timestamp">>, AbandonedT}
            ,{<<"handled_timestamp">>, HandledT}
            ,{<<"processed_timestamp">>, ProcessedT}
+           ,{<<"entered_position">>, EnteredPos}
+           ,{<<"exited_position">>, ExitedPos}
            ,{<<"abandoned_reason">>, AbandonedR}
            ,{<<"misses">>, misses_to_docs(Misses)}
            ,{<<"status">>, Status}
@@ -574,6 +617,8 @@ call_stat_to_json(#call_stat{id=Id
                              ,abandoned_timestamp=AbandonedT
                              ,handled_timestamp=HandledT
                              ,processed_timestamp=ProcessedT
+                             ,entered_position=EnteredPos
+                             ,exited_position=ExitedPos
                              ,abandoned_reason=AbandonedR
                              ,misses=Misses
                              ,status=Status
@@ -591,6 +636,8 @@ call_stat_to_json(#call_stat{id=Id
          ,{<<"Abandoned-Timestamp">>, AbandonedT}
          ,{<<"Handled-Timestamp">>, HandledT}
          ,{<<"Processed-Timestamp">>, ProcessedT}
+         ,{<<"Entered-Position">>, EnteredPos}
+         ,{<<"Exited-Position">>, ExitedPos}
          ,{<<"Abandoned-Reason">>, AbandonedR}
          ,{<<"Misses">>, misses_to_docs(Misses)}
          ,{<<"Status">>, Status}
@@ -709,6 +756,36 @@ handle_processed_stat(JObj, Props) ->
                  ,{#call_stat.status, <<"processed">>}
                 ]),
     update_call_stat(Id, Updates, Props).
+
+-spec handle_entered_stat(wh_json:object(), wh_proplist()) -> 'ok'.
+handle_entered_stat(JObj, Props) ->
+    'true' = wapi_acdc_stats:call_entered_position_v(JObj),
+
+    Id = call_stat_id(JObj),
+    Updates = props:filter_undefined([{#call_stat.entered_position, wh_json:get_value(<<"Entered-Position">>, JObj)}]),
+    update_call_stat(Id, Updates, Props).
+
+-spec handle_exited_stat(wh_json:object(), wh_proplist()) -> 'ok'.
+handle_exited_stat(JObj, Props) ->
+    'true' = wapi_acdc_stats:call_exited_position_v(JObj),
+
+    Id = call_stat_id(JObj),
+    Updates = props:filter_undefined([{#call_stat.exited_position, wh_json:get_value(<<"Exited-Position">>, JObj)}]),
+    update_call_stat(Id, Updates, Props).
+
+-spec handle_id_change(wh_json:object(), wh_proplist()) -> 'ok'.
+handle_id_change(JObj, Props) ->
+    'true' = wapi_acdc_stats:call_id_change_v(JObj),
+
+    lager:debug("Trying id change"),
+
+    gen_listener:cast(props:get_value('server', Props)
+                      ,{'replace_call_id'
+                        ,wh_json:get_value(<<"Queue-ID">>, JObj)
+                        ,wh_json:get_value(<<"Old-Call-ID">>, JObj)
+                        ,wh_json:get_value(<<"Call-ID">>, JObj)
+                       }
+                     ).
 
 -spec flush_call_stat(wh_json:object(), wh_proplist()) -> 'ok'.
 flush_call_stat(JObj, Props) ->

--- a/applications/acdc/src/acdc_stats.hrl
+++ b/applications/acdc/src/acdc_stats.hrl
@@ -28,6 +28,9 @@
           ,handled_timestamp :: api_integer() | '_'
           ,processed_timestamp :: api_integer() | '_'
 
+          ,entered_position :: pos_integer()
+          ,exited_position :: pos_integer()
+
           ,abandoned_reason :: api_binary() | '_'
 
           ,misses = [] :: agent_misses() | '_'

--- a/applications/acdc/src/wapi_acdc_queue.erl
+++ b/applications/acdc/src/wapi_acdc_queue.erl
@@ -23,6 +23,10 @@
          ,sync_req/1, sync_req_v/1
          ,sync_resp/1, sync_resp_v/1
          ,agent_change/1, agent_change_v/1
+         ,queue_member_add/1, queue_member_add_v/1
+         ,queue_member_remove/1, queue_member_remove_v/1
+         ,member_callback_reg/1, member_callback_reg_v/1
+         ,member_callback_update/1, member_callback_update_v/1
         ]).
 
 -export([agent_change_available/0
@@ -50,6 +54,10 @@
          ,publish_sync_req/1, publish_sync_req/2
          ,publish_sync_resp/2, publish_sync_resp/3
          ,publish_agent_change/1, publish_agent_change/2
+         ,publish_queue_member_add/1, publish_queue_member_add/2
+         ,publish_queue_member_remove/1, publish_queue_member_remove/2
+         ,publish_member_callback_reg/1, publish_member_callback_reg/2
+         ,publish_member_callback_update/2, publish_member_callback_update/3
         ]).
 
 -export([queue_size/2, shared_queue_name/2]).
@@ -255,7 +263,7 @@ member_connect_resp_v(JObj) ->
                                               ,<<"Wrapup-Timeout">>, <<"CDR-Url">>
                                               ,<<"Process-ID">>, <<"Agent-Process-ID">>
                                               ,<<"Record-Caller">>, <<"Recording-URL">>
-                                              ,<<"Notifications">>
+                                              ,<<"Notifications">>, <<"Callback-Number">>
                                              ]).
 -define(MEMBER_CONNECT_WIN_VALUES, [{<<"Event-Category">>, <<"member">>}
                                     ,{<<"Event-Name">>, <<"connect_win">>}
@@ -309,7 +317,7 @@ agent_timeout_v(JObj) ->
 %% Member Connect Accepted
 %%------------------------------------------------------------------------------
 -define(MEMBER_CONNECT_ACCEPTED_HEADERS, [<<"Call-ID">>]).
--define(OPTIONAL_MEMBER_CONNECT_ACCEPTED_HEADERS, [<<"Account-ID">>, <<"Agent-ID">>, <<"Process-ID">>]).
+-define(OPTIONAL_MEMBER_CONNECT_ACCEPTED_HEADERS, [<<"Account-ID">>, <<"Agent-ID">>, <<"Process-ID">>, <<"Old-Call-ID">>]).
 -define(MEMBER_CONNECT_ACCEPTED_VALUES, [{<<"Event-Category">>, <<"member">>}
                                          ,{<<"Event-Name">>, <<"connect_accepted">>}
                                         ]).
@@ -512,6 +520,137 @@ agent_change_v(Prop) when is_list(Prop) ->
 agent_change_v(JObj) -> agent_change_v(wh_json:to_proplist(JObj)).
 
 %%------------------------------------------------------------------------------
+%% Queue Position tracking
+%%------------------------------------------------------------------------------
+-spec queue_member_routing_key(api_terms()) -> ne_binary().
+-spec queue_member_routing_key(ne_binary(), ne_binary()) -> ne_binary().
+queue_member_routing_key(Props) when is_list(Props) ->
+    Id = props:get_value(<<"Queue-ID">>, Props, <<"*">>),
+    AcctId = props:get_value(<<"Account-ID">>, Props),
+    queue_member_routing_key(AcctId, Id);
+queue_member_routing_key(JObj) ->
+    Id = wh_json:get_value(<<"Queue-ID">>, JObj, <<"*">>),
+    AcctId = wh_json:get_value(<<"Account-ID">>, JObj),
+    queue_member_routing_key(AcctId, Id).
+
+queue_member_routing_key(AcctId, QID) ->
+    <<"acdc.queue.position.", AcctId/binary, ".", QID/binary>>.
+
+-define(QUEUE_MEMBER_ADD_HEADERS, [<<"Account-ID">>, <<"Queue-ID">>, <<"JObj">>]).
+-define(OPTIONAL_QUEUE_MEMBER_ADD_HEADERS, []).
+-define(QUEUE_MEMBER_ADD_VALUES, [{<<"Event-Category">>, <<"queue">>}
+                                  ,{<<"Event-Name">>, <<"member_add">>}
+                                 ]).
+-define(QUEUE_MEMBER_ADD_TYPES, []).
+
+-spec queue_member_add(api_terms()) ->
+                          {'ok', iolist()} |
+                          {'error', string()}.
+queue_member_add(Prop) when is_list(Prop) ->
+    case queue_member_add_v(Prop) of
+        'true' -> wh_api:build_message(Prop, ?QUEUE_MEMBER_ADD_HEADERS, ?OPTIONAL_QUEUE_MEMBER_ADD_HEADERS);
+        'false' -> {'error', "proplist failed validation for queue_member_add"}
+    end;
+queue_member_add(JObj) -> queue_member_add(wh_json:to_proplist(JObj)).
+
+-spec queue_member_add_v(api_terms()) -> boolean().
+queue_member_add_v(Prop) when is_list(Prop) ->
+    wh_api:validate(Prop, ?QUEUE_MEMBER_ADD_HEADERS, ?QUEUE_MEMBER_ADD_VALUES, ?QUEUE_MEMBER_ADD_TYPES);
+queue_member_add_v(JObj) -> queue_member_add_v(wh_json:to_proplist(JObj)).
+
+-define(QUEUE_MEMBER_REMOVE_HEADERS, [<<"Account-ID">>, <<"Queue-ID">>, <<"Call-ID">>]).
+-define(OPTIONAL_QUEUE_MEMBER_REMOVE_HEADERS, []).
+-define(QUEUE_MEMBER_REMOVE_VALUES, [{<<"Event-Category">>, <<"queue">>}
+                                  ,{<<"Event-Name">>, <<"member_remove">>}
+                                 ]).
+-define(QUEUE_MEMBER_REMOVE_TYPES, []).
+
+-spec queue_member_remove(api_terms()) ->
+                          {'ok', iolist()} |
+                          {'error', string()}.
+queue_member_remove(Prop) when is_list(Prop) ->
+    case queue_member_remove_v(Prop) of
+        'true' -> wh_api:build_message(Prop, ?QUEUE_MEMBER_REMOVE_HEADERS, ?OPTIONAL_QUEUE_MEMBER_REMOVE_HEADERS);
+        'false' -> {'error', "proplist failed validation for queue_member_add"}
+    end;
+queue_member_remove(JObj) -> queue_member_remove(wh_json:to_proplist(JObj)).
+
+-spec queue_member_remove_v(api_terms()) -> boolean().
+queue_member_remove_v(Prop) when is_list(Prop) ->
+    wh_api:validate(Prop, ?QUEUE_MEMBER_REMOVE_HEADERS, ?QUEUE_MEMBER_REMOVE_VALUES, ?QUEUE_MEMBER_REMOVE_TYPES);
+queue_member_remove_v(JObj) -> queue_member_remove_v(wh_json:to_proplist(JObj)).
+
+%%------------------------------------------------------------------------------
+%% Member Call Back - let the caller leave the queue but be called back
+%%  when their turn comes up
+%%------------------------------------------------------------------------------
+-spec member_callback_reg_routing_key(api_terms()) -> ne_binary().
+-spec member_callback_reg_routing_key(ne_binary(), ne_binary()) -> ne_binary().
+member_callback_reg_routing_key(Props) when is_list(Props) ->
+    Id = props:get_value(<<"Queue-ID">>, Props, <<"*">>),
+    AcctId = props:get_value(<<"Account-ID">>, Props),
+    member_callback_reg_routing_key(AcctId, Id);
+member_callback_reg_routing_key(JObj) ->
+    Id = wh_json:get_value(<<"Queue-ID">>, JObj, <<"*">>),
+    AcctId = wh_json:get_value(<<"Account-ID">>, JObj),
+    member_callback_reg_routing_key(AcctId, Id).
+
+member_callback_reg_routing_key(AcctId, QID) ->
+    <<"acdc.member.callback_reg.", AcctId/binary, ".", QID/binary>>.
+
+-define(MEMBER_CALLBACK_HEADERS, [<<"Call-ID">>, <<"Account-ID">>, <<"Queue-ID">>, <<"Number">>]).
+-define(OPTIONAL_MEMBER_CALLBACK_HEADERS, []).
+-define(MEMBER_CALLBACK_VALUES, [{<<"Event-Category">>, <<"member">>}
+                                    ,{<<"Event-Name">>, <<"callback_reg">>}
+                                   ]).
+-define(MEMBER_CALLBACK_TYPES, []).
+
+-spec member_callback_reg(api_terms()) ->
+                                {'ok', iolist()} |
+                                {'error', string()}.
+member_callback_reg(Props) when is_list(Props) ->
+    case member_callback_reg_v(Props) of
+        'true' -> wh_api:build_message(Props, ?MEMBER_CALLBACK_HEADERS, ?OPTIONAL_MEMBER_CALLBACK_HEADERS);
+        'false' -> {'error', "Proplist failed validation for member_callback_reg"}
+    end;
+member_callback_reg(JObj) ->
+    member_callback_reg(wh_json:to_proplist(JObj)).
+
+-spec member_callback_reg_v(api_terms()) -> boolean().
+member_callback_reg_v(Prop) when is_list(Prop) ->
+    wh_api:validate(Prop, ?MEMBER_CALLBACK_HEADERS, ?MEMBER_CALLBACK_VALUES, ?MEMBER_CALLBACK_TYPES);
+member_callback_reg_v(JObj) ->
+    member_callback_reg_v(wh_json:to_proplist(JObj)).
+
+%%------------------------------------------------------------------------------
+%% Member Call Back Update - inform of new call id / call when calling
+%%  back to the member
+%%------------------------------------------------------------------------------
+-define(MEMBER_CALLBACK_UPDATE_HEADERS, [<<"Call">>, <<"Account-ID">>, <<"Queue-ID">>]).
+-define(OPTIONAL_MEMBER_CALLBACK_UPDATE_HEADERS, []).
+-define(MEMBER_CALLBACK_UPDATE_VALUES, [{<<"Event-Category">>, <<"member">>}
+                                        ,{<<"Event-Name">>, <<"callback_update">>}
+                                       ]).
+-define(MEMBER_CALLBACK_UPDATE_TYPES, []).
+
+-spec member_callback_update(api_terms()) ->
+                                {'ok', iolist()} |
+                                {'error', string()}.
+member_callback_update(Props) when is_list(Props) ->
+    case member_callback_update_v(Props) of
+        'true' -> wh_api:build_message(Props, ?MEMBER_CALLBACK_UPDATE_HEADERS, ?OPTIONAL_MEMBER_CALLBACK_UPDATE_HEADERS);
+        'false' -> {'error', "Proplist failed validation for member_callback_update"}
+    end;
+member_callback_update(JObj) ->
+    member_callback_update(wh_json:to_proplist(JObj)).
+
+-spec member_callback_update_v(api_terms()) -> boolean().
+member_callback_update_v(Prop) when is_list(Prop) ->
+    wh_api:validate(Prop, ?MEMBER_CALLBACK_UPDATE_HEADERS, ?MEMBER_CALLBACK_UPDATE_VALUES, ?MEMBER_CALLBACK_UPDATE_TYPES);
+member_callback_update_v(JObj) ->
+    member_callback_update_v(wh_json:to_proplist(JObj)).
+
+%%------------------------------------------------------------------------------
 %% Bind/Unbind the queue as appropriate
 %%------------------------------------------------------------------------------
 -spec shared_queue_name(ne_binary(), ne_binary()) -> ne_binary().
@@ -565,6 +704,12 @@ bind_q(Q, AcctId, QID, ['sync_req'|T]) ->
     bind_q(Q, AcctId, QID, T);
 bind_q(Q, AcctId, QID, ['agent_change'|T]) ->
     amqp_util:bind_q_to_whapps(Q, agent_change_routing_key(AcctId, QID)),
+    bind_q(Q, AcctId, QID, T);
+bind_q(Q, AcctId, QID, ['member_addremove'|T]) ->
+    amqp_util:bind_q_to_whapps(Q, queue_member_routing_key(AcctId, QID)),
+    bind_q(Q, AcctId, QID, T);
+bind_q(Q, AcctId, QID, ['member_callback_reg'|T]) ->
+    amqp_util:bind_q_to_whapps(Q, member_callback_reg_routing_key(AcctId, QID)),
     bind_q(Q, AcctId, QID, T);
 bind_q(Q, AcctId, QID, [_|T]) -> bind_q(Q, AcctId, QID, T);
 bind_q(_, _, _, []) -> 'ok'.
@@ -643,7 +788,8 @@ publish_member_call_failure(Q, JObj) ->
     publish_member_call_failure(Q, JObj, ?DEFAULT_CONTENT_TYPE).
 publish_member_call_failure(Q, API, ContentType) ->
     {'ok', Payload} = wh_api:prepare_api_payload(API, ?MEMBER_CALL_FAIL_VALUES, fun member_call_failure/1),
-    amqp_util:targeted_publish(Q, Payload, ContentType).
+    amqp_util:targeted_publish(Q, Payload, ContentType),
+    amqp_util:callmgr_publish(Payload, ContentType, member_call_routing_key(API)).
 
 -spec publish_member_call_success(ne_binary(), api_terms()) -> 'ok'.
 -spec publish_member_call_success(ne_binary(), api_terms(), ne_binary()) -> 'ok'.
@@ -651,7 +797,8 @@ publish_member_call_success(Q, JObj) ->
     publish_member_call_success(Q, JObj, ?DEFAULT_CONTENT_TYPE).
 publish_member_call_success(Q, API, ContentType) ->
     {'ok', Payload} = wh_api:prepare_api_payload(API, ?MEMBER_CALL_SUCCESS_VALUES, fun member_call_success/1),
-    amqp_util:targeted_publish(Q, Payload, ContentType).
+    amqp_util:targeted_publish(Q, Payload, ContentType),
+    amqp_util:callmgr_publish(Payload, ContentType, member_call_routing_key(API)).
 
 -spec publish_member_connect_req(api_terms()) -> 'ok'.
 -spec publish_member_connect_req(api_terms(), ne_binary()) -> 'ok'.
@@ -732,3 +879,35 @@ publish_agent_change(JObj) ->
 publish_agent_change(API, ContentType) ->
     {'ok', Payload} = wh_api:prepare_api_payload(API, ?AGENT_CHANGE_VALUES, fun agent_change/1),
     amqp_util:whapps_publish(agent_change_publish_key(API), Payload, ContentType).
+
+-spec publish_queue_member_add(api_terms()) -> 'ok'.
+-spec publish_queue_member_add(api_terms(), ne_binary()) -> 'ok'.
+publish_queue_member_add(JObj) ->
+    publish_queue_member_add(JObj, ?DEFAULT_CONTENT_TYPE).
+publish_queue_member_add(API, ContentType) ->
+    {'ok', Payload} = wh_api:prepare_api_payload(API, ?QUEUE_MEMBER_ADD_VALUES, fun queue_member_add/1),
+    amqp_util:whapps_publish(queue_member_routing_key(API), Payload, ContentType).
+
+-spec publish_queue_member_remove(api_terms()) -> 'ok'.
+-spec publish_queue_member_remove(api_terms(), ne_binary()) -> 'ok'.
+publish_queue_member_remove(JObj) ->
+    publish_queue_member_remove(JObj, ?DEFAULT_CONTENT_TYPE).
+publish_queue_member_remove(API, ContentType) ->
+    {'ok', Payload} = wh_api:prepare_api_payload(API, ?QUEUE_MEMBER_REMOVE_VALUES, fun queue_member_remove/1),
+    amqp_util:whapps_publish(queue_member_routing_key(API), Payload, ContentType).
+
+-spec publish_member_callback_reg(api_terms()) -> 'ok'.
+-spec publish_member_callback_reg(api_terms(), ne_binary()) -> 'ok'.
+publish_member_callback_reg(JObj) ->
+    publish_member_callback_reg(JObj, ?DEFAULT_CONTENT_TYPE).
+publish_member_callback_reg(API, ContentType) ->
+    {'ok', Payload} = wh_api:prepare_api_payload(API, ?MEMBER_CALLBACK_VALUES, fun member_callback_reg/1),
+    amqp_util:whapps_publish(member_callback_reg_routing_key(API), Payload, ContentType).
+
+-spec publish_member_callback_update(ne_binary(), api_terms()) -> 'ok'.
+-spec publish_member_callback_update(ne_binary(), api_terms(), ne_binary()) -> 'ok'.
+publish_member_callback_update(Q, JObj) ->
+    publish_member_callback_update(Q, JObj, ?DEFAULT_CONTENT_TYPE).
+publish_member_callback_update(Q, API, ContentType) ->
+    {'ok', Payload} = wh_api:prepare_api_payload(API, ?MEMBER_CALLBACK_UPDATE_VALUES, fun member_callback_update/1),
+    amqp_util:targeted_publish(Q, Payload, ContentType).

--- a/applications/acdc/src/wapi_acdc_stats.erl
+++ b/applications/acdc/src/wapi_acdc_stats.erl
@@ -15,6 +15,11 @@
          ,call_handled/1, call_handled_v/1
          ,call_processed/1, call_processed_v/1
 
+         ,call_entered_position/1, call_entered_position_v/1
+         ,call_exited_position/1, call_exited_position_v/1
+
+         ,call_id_change/1, call_id_change_v/1
+
          ,call_flush/1, call_flush_v/1
 
          ,current_calls_req/1, current_calls_req_v/1
@@ -46,6 +51,11 @@
          ,publish_call_abandoned/1, publish_call_abandoned/2
          ,publish_call_handled/1, publish_call_handled/2
          ,publish_call_processed/1, publish_call_processed/2
+
+         ,publish_call_entered_position/1, publish_call_entered_position/2
+         ,publish_call_exited_position/1, publish_call_exited_position/2
+
+         ,publish_call_id_change/1, publish_call_id_change/2
 
          ,publish_call_flush/1, publish_call_flush/2
 
@@ -96,6 +106,18 @@
 -define(PROCESS_HEADERS, [<<"Agent-ID">>, <<"Processed-Timestamp">>]).
 -define(PROCESS_VALUES, ?CALL_REQ_VALUES(<<"processed">>)).
 -define(PROCESS_TYPES, []).
+
+-define(ENTERED_HEADERS, [<<"Entered-Position">>]).
+-define(ENTERED_VALUES, ?CALL_REQ_VALUES(<<"entered-position">>)).
+-define(ENTERED_TYPES, []).
+
+-define(EXITED_HEADERS, [<<"Exited-Position">>]).
+-define(EXITED_VALUES, ?CALL_REQ_VALUES(<<"exited-position">>)).
+-define(EXITED_TYPES, []).
+
+-define(ID_CHANGE_HEADERS, [<<"Old-Call-ID">>]).
+-define(ID_CHANGE_VALUES, ?CALL_REQ_VALUES(<<"id-change">>)).
+-define(ID_CHANGE_TYPES, []).
 
 -define(FLUSH_HEADERS, [<<"Call-ID">>]).
 -define(FLUSH_VALUES, ?CALL_REQ_VALUES(<<"flush">>)).
@@ -186,6 +208,57 @@ call_processed_v(Prop) when is_list(Prop) ->
 call_processed_v(JObj) ->
     call_processed_v(wh_json:to_proplist(JObj)).
 
+-spec call_entered_position(api_terms()) ->
+                            {'ok', iolist()} |
+                            {'error', string()}.
+call_entered_position(Props) when is_list(Props) ->
+    case call_entered_position_v(Props) of
+        'true' -> wh_api:build_message(Props, ?CALL_REQ_HEADERS, ?ENTERED_HEADERS);
+        'false' -> {'error', "Proplist failed validation for call_entered_position"}
+    end;
+call_entered_position(JObj) ->
+    call_entered_position(wh_json:to_proplist(JObj)).
+
+-spec call_entered_position_v(api_terms()) -> boolean().
+call_entered_position_v(Prop) when is_list(Prop) ->
+    wh_api:validate(Prop, ?CALL_REQ_HEADERS, ?ENTERED_VALUES, ?ENTERED_TYPES);
+call_entered_position_v(JObj) ->
+    call_entered_position_v(wh_json:to_proplist(JObj)).
+
+-spec call_exited_position(api_terms()) ->
+                            {'ok', iolist()} |
+                            {'error', string()}.
+call_exited_position(Props) when is_list(Props) ->
+    case call_exited_position_v(Props) of
+        'true' -> wh_api:build_message(Props, ?CALL_REQ_HEADERS, ?EXITED_HEADERS);
+        'false' -> {'error', "Proplist failed validation for call_exited_position"}
+    end;
+call_exited_position(JObj) ->
+    call_exited_position(wh_json:to_proplist(JObj)).
+
+-spec call_exited_position_v(api_terms()) -> boolean().
+call_exited_position_v(Prop) when is_list(Prop) ->
+    wh_api:validate(Prop, ?CALL_REQ_HEADERS, ?EXITED_VALUES, ?EXITED_TYPES);
+call_exited_position_v(JObj) ->
+    call_exited_position_v(wh_json:to_proplist(JObj)).
+
+-spec call_id_change(api_terms()) ->
+                            {'ok', iolist()} |
+                            {'error', string()}.
+call_id_change(Props) when is_list(Props) ->
+    case call_id_change_v(Props) of
+        'true' -> wh_api:build_message(Props, ?CALL_REQ_HEADERS, ?ID_CHANGE_HEADERS);
+        'false' -> {'error', "Proplist failed validation for call_id_change"}
+    end;
+call_id_change(JObj) ->
+    call_id_change(wh_json:to_proplist(JObj)).
+
+-spec call_id_change_v(api_terms()) -> boolean().
+call_id_change_v(Prop) when is_list(Prop) ->
+    wh_api:validate(Prop, ?CALL_REQ_HEADERS, ?ID_CHANGE_VALUES, ?ID_CHANGE_TYPES);
+call_id_change_v(JObj) ->
+    call_id_change_v(wh_json:to_proplist(JObj)).
+
 -spec call_flush(api_terms()) ->
                             {'ok', iolist()} |
                             {'error', string()}.
@@ -257,6 +330,7 @@ current_calls_err_v(JObj) ->
 -define(CURRENT_CALLS_RESP_HEADERS, [<<"Query-Time">>]).
 -define(OPTIONAL_CURRENT_CALLS_RESP_HEADERS, [<<"Waiting">>, <<"Handled">>
                                               ,<<"Abandoned">>, <<"Processed">>
+                                              ,<<"Entered-Position">>, <<"Exited-Position">>
                                              ]).
 -define(CURRENT_CALLS_RESP_VALUES, [{<<"Event-Category">>, <<"acdc_stat">>}
                                     ,{<<"Event-Name">>, <<"current_calls_resp">>}
@@ -527,7 +601,8 @@ bind_q(Q, AcctId, QID, AID, 'undefined') ->
     amqp_util:bind_q_to_whapps(Q, call_stat_routing_key(AcctId, QID)),
     amqp_util:bind_q_to_whapps(Q, status_stat_routing_key(AcctId, AID)),
     amqp_util:bind_q_to_whapps(Q, query_call_stat_routing_key(AcctId, QID)),
-    amqp_util:bind_q_to_whapps(Q, query_status_stat_routing_key(AcctId, AID));
+    amqp_util:bind_q_to_whapps(Q, query_status_stat_routing_key(AcctId, AID)),
+    amqp_util:bind_q_to_whapps(Q, call_id_change_routing_key(AcctId, QID));
 bind_q(Q, AcctId, QID, AID, ['call_stat'|L]) ->
     amqp_util:bind_q_to_whapps(Q, call_stat_routing_key(AcctId, QID)),
     bind_q(Q, AcctId, QID, AID, L);
@@ -540,8 +615,12 @@ bind_q(Q, AcctId, QID, AID, ['query_call_stat'|L]) ->
 bind_q(Q, AcctId, QID, AID, ['query_status_stat'|L]) ->
     amqp_util:bind_q_to_whapps(Q, query_status_stat_routing_key(AcctId, AID)),
     bind_q(Q, AcctId, QID, AID, L);
+bind_q(Q, AcctId, QID, AID, ['id_change'|L]) ->
+    amqp_util:bind_q_to_whapps(Q, call_id_change_routing_key(AcctId, QID)),
+    bind_q(Q, AcctId, QID, AID, L);
 bind_q(Q, AcctId, QID, AID, [_|L]) ->
-    bind_q(Q, AcctId, QID, AID, L).
+    bind_q(Q, AcctId, QID, AID, L);
+bind_q(_, _, _, _, []) -> 'ok'.
 
 unbind_q(Q, Props) ->
     QID = props:get_value('queue_id', Props, <<"*">>),
@@ -567,8 +646,12 @@ unbind_q(Q, AcctId, QID, AID, ['query_call_stat'|L]) ->
 unbind_q(Q, AcctId, QID, AID, ['query_status_stat'|L]) ->
     amqp_util:unbind_q_from_whapps(Q, query_status_stat_routing_key(AcctId, AID)),
     unbind_q(Q, AcctId, QID, AID, L);
+unbind_q(Q, AcctId, QID, AID, ['id_change'|L]) ->
+    amqp_util:unbind_q_from_whapps(Q, call_id_change_routing_key(AcctId, QID)),
+    unbind_q(Q, AcctId, QID, AID, L);
 unbind_q(Q, AcctId, QID, AID, [_|L]) ->
-    unbind_q(Q, AcctId, QID, AID, L).
+    unbind_q(Q, AcctId, QID, AID, L);
+unbind_q(_, _, _, _, []) -> 'ok'.
 
 %%--------------------------------------------------------------------
 %% @doc
@@ -608,6 +691,24 @@ publish_call_processed(JObj) ->
 publish_call_processed(API, ContentType) ->
     {'ok', Payload} = wh_api:prepare_api_payload(API, ?PROCESS_VALUES, fun call_processed/1),
     amqp_util:whapps_publish(call_stat_routing_key(API), Payload, ContentType).
+
+publish_call_entered_position(JObj) ->
+    publish_call_entered_position(JObj, ?DEFAULT_CONTENT_TYPE).
+publish_call_entered_position(API, ContentType) ->
+    {'ok', Payload} = wh_api:prepare_api_payload(API, ?ENTERED_VALUES, fun call_entered_position/1),
+    amqp_util:whapps_publish(call_stat_routing_key(API), Payload, ContentType).
+
+publish_call_exited_position(JObj) ->
+    publish_call_exited_position(JObj, ?DEFAULT_CONTENT_TYPE).
+publish_call_exited_position(API, ContentType) ->
+    {'ok', Payload} = wh_api:prepare_api_payload(API, ?EXITED_VALUES, fun call_exited_position/1),
+    amqp_util:whapps_publish(call_stat_routing_key(API), Payload, ContentType).
+
+publish_call_id_change(JObj) ->
+    publish_call_id_change(JObj, ?DEFAULT_CONTENT_TYPE).
+publish_call_id_change(API, ContentType) ->
+    {'ok', Payload} = wh_api:prepare_api_payload(API, ?ID_CHANGE_VALUES, fun call_id_change/1),
+    amqp_util:whapps_publish(call_id_change_routing_key(API), Payload, ContentType).
 
 publish_call_flush(JObj) ->
     publish_call_flush(JObj, ?DEFAULT_CONTENT_TYPE).
@@ -756,6 +857,18 @@ query_status_stat_routing_key(AcctId, 'undefined') ->
     <<"acdc_stats.query_status.", AcctId/binary, ".all">>;
 query_status_stat_routing_key(AcctId, QID) ->
     <<"acdc_stats.query_status.", AcctId/binary, ".", QID/binary>>.
+
+call_id_change_routing_key(Prop) when is_list(Prop) ->
+    call_id_change_routing_key(props:get_value(<<"Account-ID">>, Prop)
+                                  ,props:get_value(<<"Queue-ID">>, Prop)
+                                 );
+call_id_change_routing_key(JObj) ->
+    call_id_change_routing_key(wh_json:get_value(<<"Account-ID">>, JObj)
+                                  ,wh_json:get_value(<<"Queue-ID">>, JObj)
+                                 ).
+
+call_id_change_routing_key(AcctId, QID) ->
+    <<"acdc_stats.id_change.", AcctId/binary, ".", QID/binary>>.
 
 
 status_value(API) when is_list(API) -> props:get_value(<<"Status">>, API);

--- a/applications/callflow/src/cf_exe.erl
+++ b/applications/callflow/src/cf_exe.erl
@@ -513,6 +513,9 @@ handle_event(JObj, #state{cf_module_pid=PidRef
                     'true' -> 'ok'
                 end,
             'ignore';
+        {{<<"konami">>, <<"callback_reg">>}, _} ->
+            relay_amqp(JObj, [{'cf_module_pid', get_pid(PidRef)}]),
+            'ignore';
         {{<<"error">>, _}, _} ->
             case wh_json:get_value([<<"Request">>, <<"Call-ID">>], JObj) of
                 CallId -> {'reply', [{'cf_module_pid', get_pid(PidRef)}

--- a/applications/konami/src/konami_event_listener.erl
+++ b/applications/konami/src/konami_event_listener.erl
@@ -21,6 +21,7 @@
          ,bindings/0, bindings/1
          ,originate/1
 
+         ,fsms_for_callid/1
          ,fsms/0, metaflows/0
         ]).
 

--- a/applications/konami/src/module/konami_menu.erl
+++ b/applications/konami/src/module/konami_menu.erl
@@ -1,0 +1,312 @@
+%%%-------------------------------------------------------------------
+
+%%%-------------------------------------------------------------------
+-module(konami_menu).
+
+-export([handle/2]).
+-export([callback_event/1]).
+
+-include("../konami.hrl").
+
+-define(MOD_CONFIG_CAT, <<(?CONFIG_CAT)/binary, ".menu">>).
+
+-record(menu_keys, {
+           %% Record Review
+           callback = <<"1">> :: ne_binary()
+          ,change_moh = <<"2">> :: ne_binary()
+         }).
+-type menu_keys() :: #menu_keys{}.
+-define(MENU_KEY_LENGTH, 1).
+
+-record(cf_menu_data, {
+          menu_id :: api_binary()
+         ,name = <<>> :: binary()
+         ,retries = 3 :: pos_integer()
+         ,timeout = 10000 :: pos_integer()
+         ,greeting_id :: api_binary()
+         ,exit_media = 'true' :: boolean() | ne_binary()
+         ,invalid_media = 'true' :: boolean() | ne_binary()
+         ,keys = #menu_keys{} :: menu_keys()
+         ,interdigit_timeout = whapps_call_command:default_interdigit_timeout() :: pos_integer()
+         ,alt_moh = wh_json:new() :: wh_json:object()
+         ,cf_controller_queue = 'undefined'
+         ,custom_vars = wh_json:new()
+         }).
+-type menu() :: #cf_menu_data{}.
+
+%%--------------------------------------------------------------------
+%% @public
+%% @doc
+%% Entry point for this module
+%% @end
+%%--------------------------------------------------------------------
+-spec handle(wh_json:object(), whapps_call:call()) -> 'ok'.
+handle(Data, Call) ->
+    konami_event_listener:add_call_binding(whapps_call:call_id(Call), [<<"DTMF">>]),
+    Menu = get_menu_profile(Data, Call),
+    menu_loop(Menu, Call).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% The main auto-attendant loop, will execute for the number
+%% of retries playing the greeting and collecting digits till the
+%% digits are routable
+%% @end
+%%--------------------------------------------------------------------
+-spec menu_loop(menu(), whapps_call:call()) -> 'ok'.
+menu_loop(#cf_menu_data{retries=Retries}=Menu, Call) when Retries =< 0 ->
+    lager:info("maxium number of retries reached"),
+    _ = whapps_call_command:flush_dtmf(Call),
+    _ = play_exit_prompt(Menu, Call);
+menu_loop(#cf_menu_data{retries=Retries
+                        ,timeout=Timeout
+                        ,interdigit_timeout=Interdigit
+                       }=Menu, Call) ->
+    whapps_call_command:flush(Call),
+    NoopId = whapps_call_command:play(get_prompt(Menu, Call), Call),
+
+    case whapps_call_command:collect_digits(?MENU_KEY_LENGTH, Timeout, Interdigit, NoopId, Call) of
+        {'ok', <<>>} ->
+            lager:info("menu entry timeout"),
+            menu_loop(Menu#cf_menu_data{retries=Retries - 1}, Call);
+        {'ok', Digits} ->
+            %% this try_match_digits calls hunt_for_callflow() based on the digits dialed
+            %% if it finds a callflow, the main CFPid will move on to it and try_match_digits
+            %% will return true, matching here, and causing menu_loop to exit; this is
+            %% expected behaviour as CFPid has moved on from this invocation
+            case try_match_digits(Digits, Menu, Call) of
+                'return' ->
+                    menu_loop(Menu#cf_menu_data{retries=Retries - 1}, Call);
+                'true' ->
+                    lager:debug("Successful breakout menu exec"),
+                    konami_event_listener:rm_call_binding(whapps_call:call_id(Call), <<"DTMF">>);
+                'false' ->
+                    lager:info("invalid selection ~w", [Digits]),
+                    _ = play_invalid_prompt(Menu, Call),
+                    menu_loop(Menu#cf_menu_data{retries=Retries - 1}, Call)
+            end;
+        {'error', _} ->
+            lager:info("caller hungup while in the menu")
+    end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% The primary sequence logic to route the collected digits
+%% @end
+%%--------------------------------------------------------------------
+-spec try_match_digits(ne_binary(), menu(), whapps_call:call()) -> boolean().
+try_match_digits(Digits, Menu, Call) ->
+    lager:info("trying to match digits ~s", [Digits]),
+
+    case Digits of
+        <<"1">> ->
+            From = whapps_call:from_user(Call),
+            callback_loop(Call, Menu, From);
+        <<"2">> ->
+            AltMoh1 = hd(Menu#cf_menu_data.alt_moh),
+            lager:debug("Changing hold music ~p", [AltMoh1]),
+            whapps_call_command:hold(AltMoh1, Call),
+            'true';
+        _ ->
+            'false'
+    end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%%
+%% @end
+%%--------------------------------------------------------------------
+callback_loop(Call, Menu, From) ->
+    Prompt = [{'tts', <<"You will be called back at">>}
+              ,{'say', From}
+              ,{'tts', <<"If this is correct, press 1. If it is incorrect, press 2. To return to the main menu, press 3.">>}
+             ],
+    whapps_call_command:audio_macro(Prompt, Call),
+
+    case whapps_call_command:collect_digits(?MENU_KEY_LENGTH, Call) of
+        {'ok', <<>>} ->
+            'false';
+        {'ok', <<"1">>} ->
+            register_callback(Call, Menu#cf_menu_data.cf_controller_queue, Menu#cf_menu_data.custom_vars, From);
+        {'ok', <<"2">>} ->
+            whapps_call_command:tts(<<"Enter your callback number, followed by the pound sign">>, Call),
+            case whapps_call_command:collect_digits(15, 30000, 3000, Call) of
+                {'ok', <<>>} ->
+                    callback_loop(Call, Menu, From);
+                {'ok', Digits} ->
+                    callback_loop(Call, Menu, Digits);
+                _ ->
+                    'false'
+            end;
+        {'ok', <<"3">>} ->
+            'return';
+        _ ->
+            'false'
+    end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%%
+%% @end
+%%--------------------------------------------------------------------
+register_callback(Call, 'undefined', _CVs, _Number) ->
+    whapps_call_command:tts(<<"An error occurred">>, Call),
+    'false';
+register_callback(Call, ControllerQueue, CVs, Number) ->
+    lager:debug("Sending call back request to controller queue ~p", [ControllerQueue]),
+    %% Notify callflow to stop operating
+    {'ok', Payload} = wh_api:prepare_api_payload(wh_api:default_headers(?APP_NAME, ?APP_VERSION), callback_values(),
+        fun callback_event/1),
+    amqp_util:targeted_publish(ControllerQueue, Payload),
+
+    %% Notify queue listener and FSM that CHANNEL_DESTROY should not matter
+    Payload2 = [{<<"Account-ID">>, whapps_call:account_id(Call)}
+               ,{<<"Queue-ID">>, wh_json:get_value(<<"Queue-ID">>, CVs)}
+               ,{<<"Call-ID">>, whapps_call:call_id(Call)}
+               ,{<<"Number">>, Number}
+               | wh_api:default_headers(?APP_NAME, ?APP_VERSION)
+              ],
+    wapi_acdc_queue:publish_member_callback_reg(Payload2),
+
+    whapps_call_command:tts(<<"Your callback has been registered. Goodbye!">>, Call),
+    whapps_call_command:queued_hangup(Call),
+    'true'.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%%
+%% @end
+%%--------------------------------------------------------------------
+callback_values() ->
+    [{<<"Event-Category">>, <<"konami">>}
+     ,{<<"Event-Name">>, <<"callback_reg">>}].
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec callback_event(api_terms()) ->
+                         {'ok', iolist()} |
+                         {'error', string()}.
+callback_event(Props) when is_list(Props) ->
+    case callback_event_v(Props) of
+        'true' -> wh_api:build_message(Props, [], []);
+        'false' -> {'error', "Proplist failed validation for callback_event"}
+    end;
+callback_event(JObj) ->
+    callback_event(wh_json:to_proplist(JObj)).
+
+-spec callback_event_v(api_terms()) -> boolean().
+callback_event_v(Prop) when is_list(Prop) ->
+    wh_api:validate(Prop, [], callback_values(), []);
+callback_event_v(JObj) ->
+    callback_event_v(wh_json:to_proplist(JObj)).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec play_invalid_prompt(menu(), whapps_call:call()) ->
+                                 {'ok', wh_json:object()} |
+                                 {'error', atom()}.
+play_invalid_prompt(#cf_menu_data{invalid_media='false'}, _) ->
+    {'ok', wh_json:new()};
+play_invalid_prompt(#cf_menu_data{invalid_media='true'}, Call) ->
+    whapps_call_command:b_prompt(<<"menu-invalid_entry">>, Call);
+play_invalid_prompt(#cf_menu_data{invalid_media=Id}, Call) ->
+    whapps_call_command:b_play(<<$/, (whapps_call:account_db(Call))/binary, $/, Id/binary>>, Call).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec play_exit_prompt(menu(), whapps_call:call()) ->
+                              {'ok', wh_json:object()} |
+                              {'error', atom()}.
+play_exit_prompt(#cf_menu_data{exit_media='false'}, _) ->
+    {'ok', wh_json:new()};
+play_exit_prompt(#cf_menu_data{exit_media='true'}, Call) ->
+    whapps_call_command:b_prompt(<<"menu-exit">>, Call);
+play_exit_prompt(#cf_menu_data{exit_media=Id}, Call) ->
+    whapps_call_command:b_play(<<$/, (whapps_call:account_db(Call))/binary, $/, Id/binary>>, Call).
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec get_prompt(menu(), whapps_call:call()) -> ne_binary().
+get_prompt(#cf_menu_data{greeting_id='undefined'}, Call) ->
+    wh_media_util:get_prompt(<<"menu-no_prompt">>, Call);
+get_prompt(#cf_menu_data{greeting_id = <<"local_stream://", _/binary>> = ID}, _) ->
+    ID;
+get_prompt(#cf_menu_data{greeting_id=Id}, Call) ->
+    <<$/, (whapps_call:account_db(Call))/binary, $/, Id/binary>>.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%%
+%% @end
+%%--------------------------------------------------------------------
+-spec get_menu_profile(wh_json:object(), whapps_call:call()) -> menu().
+get_menu_profile(Data, Call) ->
+    Id = wh_json:get_value(<<"id">>, Data),
+    AccountDb = whapps_call:account_db(Call),
+    case couch_mgr:open_doc(AccountDb, Id) of
+        {'ok', JObj} ->
+            lager:info("loaded menu route ~s", [Id]),
+            Default = #cf_menu_data{},
+            #cf_menu_data{menu_id = Id
+                          ,name =
+                              wh_json:get_ne_value(<<"name">>, JObj, Id)
+                          ,retries =
+                              wh_json:get_integer_value(<<"retries">>, JObj, Default#cf_menu_data.retries)
+                          ,timeout =
+                              wh_json:get_integer_value(<<"timeout">>, JObj, Default#cf_menu_data.timeout)
+                          ,greeting_id =
+                              wh_json:get_ne_value([<<"media">>, <<"greeting">>], JObj)
+                          ,exit_media =
+                              (not wh_json:is_false([<<"media">>, <<"exit_media">>], JObj))
+                          andalso wh_json:get_ne_value([<<"media">>, <<"exit_media">>], JObj, 'true')
+                          ,invalid_media =
+                              (not wh_json:is_false([<<"media">>, <<"invalid_media">>], JObj))
+                          andalso wh_json:get_ne_value([<<"media">>, <<"invalid_media">>], JObj, 'true')
+                          ,interdigit_timeout =
+                              wh_util:to_integer(
+                                wh_json:find(<<"interdigit_timeout">>
+                                             ,[JObj, Data]
+                                             ,whapps_call_command:default_interdigit_timeout()
+                                            ))
+                          ,alt_moh =
+                              wh_json:get_value(<<"alt_moh">>
+                                                ,Data
+                                                ,Default#cf_menu_data.alt_moh
+                                               )
+                          ,cf_controller_queue =
+                              wh_json:get_value(<<"controller_queue">>
+                                                ,Data
+                                                ,Default#cf_menu_data.cf_controller_queue
+                                               )
+                          ,custom_vars =
+                              wh_json:get_value(<<"custom_vars">>
+                                                ,Data
+                                                ,Default#cf_menu_data.custom_vars
+                                               )
+                         };
+        {'error', R} ->
+            lager:info("failed to load menu route ~s, ~w", [Id, R]),
+            #cf_menu_data{}
+    end.

--- a/core/whistle_apps-1.0.0/src/whapps_controller.erl
+++ b/core/whistle_apps-1.0.0/src/whapps_controller.erl
@@ -15,6 +15,7 @@
          ,stop_app/1
          ,restart_app/1
          ,running_apps/0, running_apps/1
+         ,app_running/1
          ,list_apps/0
         ]).
 
@@ -117,6 +118,16 @@ running_apps_list() ->
     of
         [] -> "whapps have not started yet, check that rabbitmq and bigcouch/haproxy are running at the configured addresses";
         Resp -> Resp
+    end.
+
+app_running(AppName) ->
+    case [App
+          || App <- running_apps_list(),
+             AppName =:= App
+         ]
+    of
+        [] -> false;
+        _ -> true
     end.
 
 initialize_whapps() ->


### PR DESCRIPTION
Basic implementation of breakout menus and callbacks added to ACDC queues
Periodic position announcements while waiting for agents to take your call

Press \* during queue MOH to enter breakout menu (requires metaflows node in queue doc)
Then, press 1 or 2 for callback and change MOH respectively
