### PR TITLE
Fixed #35 - edge case when restarts occurred around modb switch

### DIFF
--- a/applications/acdc/src/acdc_agent_stats.erl
+++ b/applications/acdc/src/acdc_agent_stats.erl
@@ -375,26 +375,10 @@ archive_status_data(Srv, 'false') ->
              }],
     maybe_archive_status_data(Srv, Match).
 
-archive_status_data_match() ->
-	[{
-		#status_stat{
-			is_archived = '$1',
-			_ = '_'
-		},
-		[{'=:=', '$1', 'false'}],
-		['$_']
-	}].
-
 maybe_archive_status_data(Srv, Match) ->
-	case ets:select(acdc_agent_stats:status_table_id(), archive_status_data_match()) of
-		[] -> ok;
-		Stats2 -> lager:debug("Count of status stats not yet archived: ~p", [length(Stats2)])
-	end,
-
-    case ets:select(acdc_agent_stats:status_table_id(), Match) of
+	case ets:select(acdc_agent_stats:status_table_id(), Match) of
         [] -> 'ok';
         Stats ->
-        	lager:debug("Count of status stats to archive: ~p", [length(Stats)]),
             couch_mgr:suppress_change_notice(),
             ToSave = lists:foldl(fun archive_status_fold/2, dict:new(), Stats),
             [couch_mgr:save_docs(acdc_stats_util:db_name(Acct), Docs)

--- a/applications/acdc/src/acdc_agent_util.erl
+++ b/applications/acdc/src/acdc_agent_util.erl
@@ -81,7 +81,18 @@ most_recent_db_status(AccountId, AgentId) ->
            ],
     case couch_mgr:get_results(acdc_stats_util:db_name(AccountId), <<"agent_stats/status_log">>, Opts) of
         {'ok', [StatusJObj]} -> {'ok', wh_json:get_value(<<"value">>, StatusJObj)};
-        {'ok', []} -> {'ok', <<"unknown">>};
+        {'ok', []} ->
+        	lager:debug("Could not find a recent status for agent ~p, checking previous modb", [AgentId]),
+        	case couch_mgr:get_results(acdc_stats_util:prev_modb(AccountId), <<"agent_stats/status_log">>, Opts) of
+        		{'ok', [StatusJObj2]} -> {'ok', wh_json:get_value(<<"value">>, StatusJObj2)};
+        		{'ok', []} -> {'ok', <<"unknown">>};
+				{'error', 'not_found'} ->
+					lager:debug("No previous modb found, returning unknown status"),
+					{'ok', <<"unknown">>};
+		        {'error', _E} ->
+		            lager:debug("error querying view: ~p", [_E]),
+		            {'ok', <<"unknown">>}
+		    end;
         {'error', 'not_found'} ->
             acdc_maintenance:refresh_account(AccountId),
             timer:sleep(150),

--- a/applications/acdc/src/acdc_stats.erl
+++ b/applications/acdc/src/acdc_stats.erl
@@ -268,11 +268,9 @@ handle_info({'ETS-TRANSFER', _TblId, _From, _Data}, State) ->
     lager:debug("ETS control for ~p transferred to me for writing", [_TblId]),
     {'noreply', State};
 handle_info(?ARCHIVE_MSG, State) ->
-	lager:debug("Starting archive of acdc_stats data"),
     _ = archive_data(),
     {'noreply', State#state{archive_ref=start_archive_timer()}};
 handle_info(?CLEANUP_MSG, State) ->
-	lager:debug("Starting cleanup of acdc_stats data"),
     _ = cleanup_data(self()),
     {'noreply', State#state{cleanup_ref=start_cleanup_timer()}};
 handle_info(_Msg, State) ->

--- a/applications/acdc/src/acdc_stats_util.erl
+++ b/applications/acdc/src/acdc_stats_util.erl
@@ -15,6 +15,7 @@
 
          ,get_query_limit/1
          ,db_name/1
+         ,prev_modb/1
         ]).
 
 -include("acdc.hrl").
@@ -50,3 +51,14 @@ get_query_limit(JObj) ->
 -spec db_name(ne_binary()) -> ne_binary().
 db_name(Account) ->
     wh_util:format_account_mod_id(Account).
+
+-spec prev_modb(ne_binary()) -> ne_binary().
+prev_modb(Account) ->
+	{{Year, Month, _}, _} = calendar:now_to_universal_time(os:timestamp()),
+	prev_modb(Account, Year, Month-1).
+
+-spec prev_modb(ne_binary(), calendar:year(), integer()) -> ne_binary().
+prev_modb(Account, Year, 0) ->
+	prev_modb(Account, Year-1, 12);
+prev_modb(Account, Year, Month) ->
+	wh_util:format_account_id(Account, Year, Month).


### PR DESCRIPTION
If the agent did not have a status update for the month, stored
in the modb, the lookup would return an empty list and the
agent would default to "ready" state. Search now includes the
previous modb if it exists, fails to prev. default otherwise
